### PR TITLE
modified upgradeAvatarAttribute code

### DIFF
--- a/src/main/java/com/purgersmight/purgersmightapp/dto/UpdateAvatarAttributeReqDto.java
+++ b/src/main/java/com/purgersmight/purgersmightapp/dto/UpdateAvatarAttributeReqDto.java
@@ -11,6 +11,8 @@ public class UpdateAvatarAttributeReqDto {
     private String username;
     private AttributeType attributeType;
     private int cost;
+    private boolean isIncrease;
+
 
     public UpdateAvatarAttributeReqDto(){}
 }

--- a/src/main/java/com/purgersmight/purgersmightapp/utils/UpdateAvatarAttribute.java
+++ b/src/main/java/com/purgersmight/purgersmightapp/utils/UpdateAvatarAttribute.java
@@ -20,9 +20,25 @@ public class UpdateAvatarAttribute {
 
         if (checkIfAvatarHasEnoughPoints(avatar, updateAvatarAttributeReqDto.getCost())) {
 
-            avatar.setKenjaPoints(avatar.getKenjaPoints() - updateAvatarAttributeReqDto.getCost());
+            if (updateAvatarAttributeReqDto.isIncrease()) {
 
-            updateAvatar(avatar, updateAvatarAttributeReqDto.getAttributeType());
+                avatar.setKenjaPoints(avatar.getKenjaPoints() - updateAvatarAttributeReqDto.getCost());
+
+            } else {
+
+                if (avatar.getHealth().getActual().intValue() > 50 && updateAvatarAttributeReqDto.getAttributeType() == AttributeType.HEALTH
+                        || avatar.getManna().getActual().intValue() > 30 && updateAvatarAttributeReqDto.getAttributeType() == AttributeType.MANNA) {
+
+                    avatar.setKenjaPoints(avatar.getKenjaPoints() + 1);
+
+                } else {
+
+                    return new UpdateAvatarAttributeResDto(false, avatar);
+
+                }
+
+            }
+            updateAvatar(avatar, updateAvatarAttributeReqDto.getAttributeType(), updateAvatarAttributeReqDto.isIncrease());
 
             return new UpdateAvatarAttributeResDto(true, avatar);
 
@@ -37,16 +53,30 @@ public class UpdateAvatarAttribute {
         return avatar.getKenjaPoints() >= cost;
     }
 
-    private void updateAvatar(Avatar avatar, AttributeType attributeType) {
+    private void updateAvatar(Avatar avatar, AttributeType attributeType, boolean isIncrease) {
 
         if (attributeType == AttributeType.HEALTH) {
 
-            avatar.getHealth().setActual(avatar.getHealth().getActual() + 10);
+            if (isIncrease) {
+
+                avatar.getHealth().setActual(avatar.getHealth().getActual() + 10);
+
+            } else {
+
+                avatar.getHealth().setActual(avatar.getHealth().getActual() - 10);
+            }
         }
 
         if (attributeType == AttributeType.MANNA) {
 
-            avatar.getManna().setActual(avatar.getManna().getActual() + 5);
+            if (isIncrease) {
+
+                avatar.getManna().setActual(avatar.getManna().getActual() + 5);
+
+            } else {
+
+                avatar.getManna().setActual(avatar.getManna().getActual() - 5);
+            }
         }
 
         avatarService.updateAvatar(avatar);

--- a/src/test/java/com/purgersmight/purgersmightapp/controllers/UpdateAvatarAttributeControllerTest.java
+++ b/src/test/java/com/purgersmight/purgersmightapp/controllers/UpdateAvatarAttributeControllerTest.java
@@ -37,7 +37,7 @@ public class UpdateAvatarAttributeControllerTest {
 
     @Test
     public void updateAvatarAttribute__Test1() throws Exception {
-        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.HEALTH, 1);
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.HEALTH, 1, true);
 
         String jsonReq = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeReqDto);
 
@@ -69,7 +69,7 @@ public class UpdateAvatarAttributeControllerTest {
 
     @Test
     public void updateAvatarAttribute__Test2() throws Exception {
-        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.MANNA, 1);
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.MANNA, 1, true);
 
         String jsonReq = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeReqDto);
 
@@ -101,7 +101,7 @@ public class UpdateAvatarAttributeControllerTest {
 
     @Test
     public void updateAvatarAttribute__Test3() throws Exception {
-        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.MANNA, 1);
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.MANNA, 1, true);
 
         String jsonReq = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeReqDto);
 
@@ -111,6 +111,146 @@ public class UpdateAvatarAttributeControllerTest {
         when(avatarService.getAvatarByUsername("Angie")).thenReturn(avatar);
 
         UpdateAvatarAttributeResDto updateAvatarAttributeResDto = new UpdateAvatarAttributeResDto(false, avatar);
+
+        String jsonRes = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeResDto);
+
+        mockMvc.perform(put("/update-avatar-attribute")
+                .with(user("admin").password("admin123").roles("USER", "ADMIN"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .content(jsonReq)
+                .accept(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+                .andExpect(content().json(jsonRes))
+                .andReturn();
+
+        verify(avatarService, times(1)).getAvatarByUsername("Angie");
+    }
+
+    @Test
+    public void updateAvatarAttribute__Test4() throws Exception {
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.MANNA, 0, false);
+
+        String jsonReq = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeReqDto);
+
+        Avatar avatar = Avatar.getStarterAvatar("Angie");
+        avatar.getHealth().setActual(100);
+        avatar.getManna().setActual(60);
+        avatar.setKenjaPoints(0);
+
+        when(avatarService.getAvatarByUsername("Angie")).thenReturn(avatar);
+
+        Avatar avatarRes = Avatar.getStarterAvatar("Angie");
+        avatarRes.getHealth().setActual(100);
+        avatarRes.getManna().setActual(55);
+        avatarRes.setKenjaPoints(1);
+
+        UpdateAvatarAttributeResDto updateAvatarAttributeResDto = new UpdateAvatarAttributeResDto(true, avatarRes);
+
+        String jsonRes = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeResDto);
+
+        mockMvc.perform(put("/update-avatar-attribute")
+                .with(user("admin").password("admin123").roles("USER", "ADMIN"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .content(jsonReq)
+                .accept(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+                .andExpect(content().json(jsonRes))
+                .andReturn();
+
+        verify(avatarService, times(1)).getAvatarByUsername("Angie");
+    }
+
+    @Test
+    public void updateAvatarAttribute__Test5() throws Exception {
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.HEALTH, 0, false);
+
+        String jsonReq = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeReqDto);
+
+        Avatar avatar = Avatar.getStarterAvatar("Angie");
+        avatar.getHealth().setActual(100);
+        avatar.getManna().setActual(60);
+        avatar.setKenjaPoints(0);
+
+        when(avatarService.getAvatarByUsername("Angie")).thenReturn(avatar);
+
+        Avatar avatarRes = Avatar.getStarterAvatar("Angie");
+        avatarRes.getHealth().setActual(90);
+        avatarRes.getManna().setActual(60);
+        avatarRes.setKenjaPoints(1);
+
+        UpdateAvatarAttributeResDto updateAvatarAttributeResDto = new UpdateAvatarAttributeResDto(true, avatarRes);
+
+        String jsonRes = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeResDto);
+
+        mockMvc.perform(put("/update-avatar-attribute")
+                .with(user("admin").password("admin123").roles("USER", "ADMIN"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .content(jsonReq)
+                .accept(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+                .andExpect(content().json(jsonRes))
+                .andReturn();
+
+        verify(avatarService, times(1)).getAvatarByUsername("Angie");
+    }
+
+    @Test
+    public void updateAvatarAttribute__Test6() throws Exception {
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.HEALTH, 0, false);
+
+        String jsonReq = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeReqDto);
+
+        Avatar avatar = Avatar.getStarterAvatar("Angie");
+        avatar.getHealth().setActual(50);
+        avatar.getManna().setActual(60);
+        avatar.setKenjaPoints(0);
+
+        when(avatarService.getAvatarByUsername("Angie")).thenReturn(avatar);
+
+        Avatar avatarRes = Avatar.getStarterAvatar("Angie");
+        avatarRes.getHealth().setActual(50);
+        avatarRes.getManna().setActual(60);
+        avatarRes.setKenjaPoints(0);
+
+        UpdateAvatarAttributeResDto updateAvatarAttributeResDto = new UpdateAvatarAttributeResDto(false, avatarRes);
+
+        String jsonRes = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeResDto);
+
+        mockMvc.perform(put("/update-avatar-attribute")
+                .with(user("admin").password("admin123").roles("USER", "ADMIN"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .characterEncoding("UTF-8")
+                .content(jsonReq)
+                .accept(MediaType.APPLICATION_JSON))
+//                .andExpect(status().isOk())
+                .andExpect(content().json(jsonRes))
+                .andReturn();
+
+        verify(avatarService, times(1)).getAvatarByUsername("Angie");
+    }
+
+    @Test
+    public void updateAvatarAttribute__Test7() throws Exception {
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie", AttributeType.MANNA, 0, false);
+
+        String jsonReq = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeReqDto);
+
+        Avatar avatar = Avatar.getStarterAvatar("Angie");
+        avatar.getHealth().setActual(50);
+        avatar.getManna().setActual(60);
+        avatar.setKenjaPoints(0);
+
+        when(avatarService.getAvatarByUsername("Angie")).thenReturn(avatar);
+
+        Avatar avatarRes = Avatar.getStarterAvatar("Angie");
+        avatarRes.getHealth().setActual(50);
+        avatarRes.getManna().setActual(55);
+        avatarRes.setKenjaPoints(1);
+
+        UpdateAvatarAttributeResDto updateAvatarAttributeResDto = new UpdateAvatarAttributeResDto(true, avatarRes);
 
         String jsonRes = ObjectMapperUtils.getObjectMapper().writeValueAsString(updateAvatarAttributeResDto);
 

--- a/src/test/java/com/purgersmight/purgersmightapp/utils/UpdateAvatarAttributeTest.java
+++ b/src/test/java/com/purgersmight/purgersmightapp/utils/UpdateAvatarAttributeTest.java
@@ -30,7 +30,7 @@ public class UpdateAvatarAttributeTest {
     @Test
     public void updateAvatarAttribute_UpdateHealthReturnTrue_Test1() {
 
-        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie1", AttributeType.HEALTH, 1);
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie1", AttributeType.HEALTH, 1, true);
 
         Avatar avatar = Avatar.getStarterAvatar("Angie1");
         avatar.setKenjaPoints(2);
@@ -49,7 +49,7 @@ public class UpdateAvatarAttributeTest {
     @Test
     public void updateAvatarAttribute_UpdateMannaReturnTrue_Test2() {
 
-        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie1", AttributeType.MANNA, 2);
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie1", AttributeType.MANNA, 2, true);
 
         Avatar avatar = Avatar.getStarterAvatar("Angie1");
         avatar.setKenjaPoints(3);
@@ -68,7 +68,7 @@ public class UpdateAvatarAttributeTest {
     @Test
     public void updateAvatarAttribute_ReturnFalse_Test3() {
 
-        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie1", AttributeType.HEALTH, 1);
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie1", AttributeType.HEALTH, 1, true);
 
         Avatar avatar = Avatar.getStarterAvatar("Angie1");
         avatar.setKenjaPoints(0);
@@ -83,4 +83,44 @@ public class UpdateAvatarAttributeTest {
 
         assertEquals(100, avatar.getHealth().getActual().intValue());
     }
+
+    @Test
+    public void updateAvatarAttribute_ReturnTrue_Test4() {
+
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie1", AttributeType.HEALTH, 0, false);
+
+        Avatar avatar = Avatar.getStarterAvatar("Angie1");
+        avatar.setKenjaPoints(0);
+
+        when(avatarService.getAvatarByUsername("Angie1")).thenReturn(avatar);
+
+        UpdateAvatarAttributeResDto result = updateAvatarAttribute.updateAttributes(updateAvatarAttributeReqDto);
+
+        assertTrue(result.isSuccess());
+
+        assertEquals(1,result.getAvatar().getKenjaPoints());
+
+        assertEquals(90, avatar.getHealth().getActual().intValue());
+    }
+
+    @Test
+    public void updateAvatarAttribute_ReturnFalse_Test4() {
+
+        UpdateAvatarAttributeReqDto updateAvatarAttributeReqDto = new UpdateAvatarAttributeReqDto("Angie1", AttributeType.HEALTH, 0, false);
+
+        Avatar avatar = Avatar.getStarterAvatar("Angie1");
+        avatar.setKenjaPoints(2);
+        avatar.getHealth().setActual(50);
+
+        when(avatarService.getAvatarByUsername("Angie1")).thenReturn(avatar);
+
+        UpdateAvatarAttributeResDto result = updateAvatarAttribute.updateAttributes(updateAvatarAttributeReqDto);
+
+        assertFalse(result.isSuccess());
+
+        assertEquals(2,result.getAvatar().getKenjaPoints());
+
+        assertEquals(50, avatar.getHealth().getActual().intValue());
+    }
+
 }


### PR DESCRIPTION
Had to modify the code so that feature works as intended, code only allowed players to decrease their points if both conditions were meet manna > 30 and health > 50. 

e.g player should still be allowed to reduce their manna as long as it is not less than 30 irrespective to the players health and vice versa the player should be able to decrease their health attribute as long as their health is greater than 50 irrespective of their manna. 