### PR TITLE
Battle ended bug now fixed

### DIFF
--- a/src/main/java/com/purgersmight/purgersmightapp/services/BattleService.java
+++ b/src/main/java/com/purgersmight/purgersmightapp/services/BattleService.java
@@ -62,6 +62,8 @@ public class BattleService {
 
             pvpEventService.removePvpEventById(pvpEvent.getEventId());
 
+            pvpEventService.resetPlayersPvpEventStatus(pvpEvent.getPlayer1(), pvpEvent.getPlayer2());
+
             updateAvatarsInDB(pvpEvent.getPlayer1(), pvpEvent.getPlayer2());
 
             return new AttackPlayerResDto(true, pvpEvent.getWhosTurn(), pvpEvent);

--- a/src/test/java/com/purgersmight/purgersmightapp/services/PvpEventServiceTest.java
+++ b/src/test/java/com/purgersmight/purgersmightapp/services/PvpEventServiceTest.java
@@ -259,4 +259,30 @@ public class PvpEventServiceTest {
         assertNotNull(result.getPvpEvent());
     }
 
+    @Test
+    public void resetPlayersPvpStatus_playersShouldNotHaveEventIdOrBeInEvent_Test18() {
+        Avatar avatar1 = Avatar.getStarterAvatar("Angie1");
+
+        avatar1.setEventId("eventId");
+
+        avatar1.setInEvent(true);
+
+        Avatar avatar2 = Avatar.getStarterAvatar("Angie2");
+
+        avatar2.setEventId("eventId");
+
+        avatar2.setInEvent(true);
+
+        pvpEventService.resetPlayersPvpEventStatus(avatar1, avatar2);
+
+        assertFalse(avatar1.isInEvent());
+
+        assertFalse(avatar2.isInEvent());
+
+        assertEquals("", avatar1.getEventId());
+
+        assertEquals("", avatar2.getEventId());
+
+    }
+
 }


### PR DESCRIPTION
When players have finished a battle and they click on the go back to home button, they will go to the home page without being taken straight back to the pvp-room page being caught in a loop